### PR TITLE
fix(win32): changes to allow working on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "cover": "nyc --reporter=lcov --reporter=text --reporter=html npm run test",
     "check-coverage": "nyc check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "lint": "eslint .",
-    "test": "ava 'src/**/*.test.js' --verbose --require ./other/setup-ava-env.js",
+    "test": "ava src/**/*.test.js --verbose --require ./other/setup-ava-env.js",
     "test:scoped": "ava --verbose --require ./other/setup-ava-env.js",
     "test:all": "npm-run-all --parallel test test:configs",
     "test:configs": "ava tests/configs.js --verbose --require ./other/setup-ava-env.js",
@@ -35,7 +35,7 @@
     "lodash": "4.4.0"
   },
   "devDependencies": {
-    "ava": "0.11.0",
+    "ava": "0.12.0",
     "babel-cli": "6.5.1",
     "babel-core": "6.5.2",
     "babel-preset-es2015": "6.5.0",

--- a/src/validators/context/index.test.js
+++ b/src/validators/context/index.test.js
@@ -3,7 +3,7 @@ import contextValidator from '.'
 const {validate} = contextValidator
 
 test('passes with an absolute path', t => {
-  const absolutePath = '/foo/bar/baz'
+  const absolutePath = process.platform === 'win32' ? 'C://foo/bar/baz' : '/foo/bar/baz'
   const result = validate(absolutePath)
   t.notOk(result)
 })

--- a/src/validators/entry/index.test.js
+++ b/src/validators/entry/index.test.js
@@ -28,8 +28,8 @@ test('fails with an array of one string that does not exist', t => {
   const message = validate(entry, {config})
   t.ok(message)
   t.false(message.includes(' - '))
-  t.true(message.includes('/fake'))
-  t.false(message.includes('/exists'))
+  t.true(message.includes('fake'))
+  t.false(message.includes('exists1'))
 })
 
 test('fails with an array of multiple strings that do not exist', t => {
@@ -37,10 +37,10 @@ test('fails with an array of multiple strings that do not exist', t => {
   const config = {}
   const message = validate(entry, {config})
   t.ok(message)
-  t.false(message.includes('/exists'))
+  t.false(message.includes('exists1'))
   t.true(message.includes(' - '))
-  t.true(message.includes('/fake1'))
-  t.true(message.includes('/fake2'))
+  t.true(message.includes('fake1'))
+  t.true(message.includes('fake2'))
 })
 
 test('passes with an object', t => {
@@ -59,9 +59,9 @@ test('fails with an object with a single failure', t => {
   }
   const config = {}
   const message = validate(entry, {config})
-  t.false(message.includes('/exists'))
+  t.false(message.includes('exists1'))
   t.false(message.includes(' - '))
-  t.true(message.includes('/fake1'))
+  t.true(message.includes('fake1'))
 })
 
 test('fails with an object with multiple failures', t => {
@@ -71,10 +71,11 @@ test('fails with an object with multiple failures', t => {
   }
   const config = {}
   const message = validate(entry, {config})
-  t.false(message.includes('/exists'))
+  t.false(message.includes('exists1'))
   t.true(message.includes(' - '))
-  t.true(message.includes('/fake1'))
-  t.true(message.includes('/fake2'))
+  t.true(message.includes('fake1'))
+  t.true(message.includes('fake2'))
+  t.false(message.includes('fake3'))
 })
 
 test(`fails with anything that's not a string, array, or object`, t => {

--- a/tests/configs.js
+++ b/tests/configs.js
@@ -2,7 +2,7 @@
 import test from 'ava'
 import sinon from 'sinon'
 import passingConfigs from './passing-configs'
-import webpackValidator from '../'
+import webpackValidator from '../src'
 
 let originalConsoleLog
 


### PR DESCRIPTION
Dude! Probably the most challenging submit I've had to date on Github.... Here you go.

-- no single-quotes in NPM package, escape with \"
-- **npm test cover** and ava bump .... reworked, wasnt getting output (no lines)
-- **context/index.test.js** .. absolute paths diff in windows
-- **entry/index.test.js** .. folder paths between systems ("/" vs "\")
-- **test/configs.js** ... couldn't find import

Reminder : remove the eslint rule for LF only

"npm run validate" run w/o errors. Please check