### PR TITLE
Add support for postcss loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lodash": "4.4.0"
   },
   "devDependencies": {
+    "autoprefixer": "6.3.3",
     "ava": "0.12.0",
     "babel-cli": "6.5.1",
     "babel-core": "6.5.2",
@@ -51,6 +52,7 @@
     "deindent": "0.1.0",
     "eslint": "1.10.3",
     "eslint-config-kentcdodds": "5.1.0",
+    "extract-text-webpack-plugin": "^1.0.1",
     "ghooks": "1.0.3",
     "glob": "7.0.0",
     "html-webpack-plugin": "2.8.2",

--- a/src/validators/index.js
+++ b/src/validators/index.js
@@ -1,9 +1,11 @@
 import {flatten} from 'lodash'
+
 import context from './context'
 import entry from './entry'
 import output from './output'
 import module from './module'
 import plugins from './plugins'
+import postcss from './postcss'
 import externals from './externals'
 import node from './node'
 import stats from './stats'
@@ -39,6 +41,7 @@ export default flatten([
   target,
   bail,
   profile,
+  postcss,
   cache,
   amd,
   loader,

--- a/src/validators/postcss/index.js
+++ b/src/validators/postcss/index.js
@@ -1,0 +1,5 @@
+import {noop} from 'lodash'
+export default {
+  key: 'postcss',
+  validate: noop,
+}

--- a/src/validators/postcss/index.js
+++ b/src/validators/postcss/index.js
@@ -1,5 +1,20 @@
-import {noop} from 'lodash'
+import {isPlainObject, values, every} from 'lodash'
+
 export default {
   key: 'postcss',
-  validate: noop,
+  validate: validateEntry,
+}
+
+function validateEntry(val) {
+  if (typeof val !== 'function') {
+    return {warning: 'The documented way of specifying postcss options is supplying a function.'}
+  } else {
+    const options = val()
+    if (!Array.isArray(options) && !(isPlainObject(options) && every(values(options), Array.isArray))) {
+      return {
+        warning: 'The postcss function is expected to return an array ' +
+                 'of plugins or an object whose values are arrays of plugins.',
+      }
+    }
+  }
 }

--- a/src/validators/postcss/index.test.js
+++ b/src/validators/postcss/index.test.js
@@ -1,0 +1,28 @@
+import test from 'ava'
+import postcssValidator from '.'
+const {validate} = postcssValidator
+
+test('passes with a function that returns an array', t => {
+  const input = () => ['foo']
+  const result = validate(input)
+  t.notOk(result)
+})
+
+test(`passes with a function that returns an object who's values are arrays`, t => {
+  const input = () => ({foo: ['bar'], baz: ['bar']})
+  const result = validate(input)
+  t.notOk(result)
+})
+
+test(`fails for non-function input`, t => {
+  const input = ['foo']
+  const result = validate(input)
+  t.ok(result)
+})
+
+test(`fails if function returns something different than a) an object whose values are arrays or b) an array`, t => {
+  const input = () => 'foo'
+  const result = validate(input)
+  t.ok(result)
+})
+

--- a/tests/passing-configs/pac.js
+++ b/tests/passing-configs/pac.js
@@ -1,0 +1,78 @@
+/**
+ * https://github.com/jonathanewerner/pac
+ * An Electron packager manager desktop app
+ */
+
+const path = require('path');
+const autoprefixer = require('autoprefixer');
+const webpack = require('webpack');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+const lessModuleLoader = (prod) => {
+  const cssModulesOptions = prod ? '' : '&localIdentName=[name]__[local]___[hash:base64:5]';
+  const _loaders = `css?modules${cssModulesOptions}!postcss!less`;
+  return {
+    test: /\.less.module$/,
+    loader: !prod ? `style!${_loaders}` :
+      ExtractTextPlugin.extract('style', _loaders, {publicPath: ''}),
+  };
+};
+
+// const production = process.env.NODE_ENV === 'production';
+const production = true;
+
+const config = {
+  resolve: {
+    extensions: ['', '.js', '.jsx'],
+    modulesDirectories: ['node_modules', 'src'],
+  },
+  entry: {
+    app: ['./configs.js'],
+  },
+  output: {
+    path: path.join(__dirname, 'public'),
+    publicPath: '/public/',
+    filename: 'bundle.js',
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        include: /src/,
+        loader: 'babel',
+      },
+      {
+        test: /\.less$/,
+        loader: 'style-loader!css-loader!autoprefixer-loader?{browsers:["last 2 version"]}!less-loader',
+      },
+      {
+        test: /\.(?:eot|ttf|woff2?)$/,
+        loader: 'file-loader?name=[path][name]-[hash:6].[ext]&context=assets',
+      },
+    ].concat([
+      lessModuleLoader(false),
+    ]),
+  },
+  postcss: [
+    autoprefixer({browsers: ['last 2 versions']}),
+  ],
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {NODE_ENV: JSON.stringify(process.env.NODE_ENV)},
+    }),
+
+    // Moment.js imports the locales dynamically which is why webpack will include all 60 locales (>300kb)
+    // if we don't override this behaviour.
+    // Here we "whitelist" the paths that will be imported when moment/locales/* is imported
+    // We tell it that we are interested in de, en-gb, da & nl. Afrikaans etc. will stay out. :)
+    // This results in a bundle size reduction of 300kb / 150KB minified
+    new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /(de|en-gb|da|nl)$/),
+  ].concat(production ? [
+    new webpack.optimize.UglifyJsPlugin({
+      // compress: {drop_console: true},
+      sourceMap: false, // This means dropping build time from ~45 sec to ~32 sec
+    })] : []),
+  devtool: 'hidden-source-map',
+};
+
+module.exports = config;

--- a/tests/passing-configs/pac.js
+++ b/tests/passing-configs/pac.js
@@ -53,9 +53,9 @@ const config = {
       lessModuleLoader(false),
     ]),
   },
-  postcss: [
-    autoprefixer({browsers: ['last 2 versions']}),
-  ],
+  postcss: function() {
+    return [autoprefixer({browsers: ['last 2 versions']})];
+  },
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {NODE_ENV: JSON.stringify(process.env.NODE_ENV)},


### PR DESCRIPTION
I added "skeletonic" support for the `postcss` property used by [postcss-loader](https://github.com/postcss/postcss-loader) and added a webpack config of mine to verify acceptance.

This is a cool project, I'd like to get involved. :+1: 