### PR TITLE
Update to AVA 0.13 and document testing workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,17 @@ directory with a sensible name. See the
 [configuration-validator](https://github.com/kentcdodds/configuration-validator)
 documentation for information on what you need to create a validator.
 
-I recommend that you run `npm run watch:test:all` while developing your validator (and your
-validator's test) to make sure you're writing the validator to cover the use cases of the
-configs we have in the project.
+### Testing workflow
+- Use `npm run watch:test` for watching unit tests during development. For faster reload
+you can also run `npm run watch:test src/validators/<your-validator>/*.test.js` to only
+run the tests currently relevant to you.
+- To integration-test that your changes don't break existing valid configs in
+`tests/passing-configs/*.js`, run `npm run test:configs`.
+- To check both unit and integration tests, run `npm run test:all`.
+- To only check a config you are currently testing against, temporarily edit
+`tests/specific-config.js` and run `npm run test:specific:config`
+
+All mentioned `test:...` commands are also available in a `watch:test:...` version.
 
 ## Contributing configs
 

--- a/package.json
+++ b/package.json
@@ -10,20 +10,24 @@
     "prebuild": "rimraf dist",
     "validate": "npm-run-all --parallel lint cover build test:configs --sequential check-coverage",
     "build": "babel -d dist src",
-    "cover": "nyc --reporter=lcov --reporter=text --reporter=html npm run test",
     "check-coverage": "nyc check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "lint": "eslint .",
-    "test": "ava \"src/**/*.test.js\" --verbose --require ./other/setup-ava-env.js",
-    "test:scoped": "ava --verbose --require ./other/setup-ava-env.js",
-    "test:all": "npm-run-all --parallel test test:configs",
-    "test:configs": "ava tests/configs.js --verbose --require ./other/setup-ava-env.js",
-    "test:specific:config": "ava tests/specific-config.js --verbose --require ./other/setup-ava-env.js ",
-    "watch:test": "nodemon --quiet --watch src --exec npm run test -s",
-    "watch:test:scoped": "nodemon --quiet --watch src --exec npm run test:entry -s",
-    "watch:test:all": "nodemon --quiet --watch src --watch tests --exec npm run test:all -s",
-    "watch:test:configs": "nodemon --quiet --watch src --watch tests --exec npm run test:configs -s",
+
+    "cover": "nyc --reporter=lcov --reporter=text --reporter=html npm run test",
     "watch:cover": "nodemon --quiet --watch src --exec npm run cover -s",
-    "watch:test:specific:config": "nodemon --quiet --watch src --watch tests --exec npm run test:specific:config -s",
+
+    "test": "ava",
+    "watch:test": "npm run test -- -w",
+
+    "test:configs": "ava tests/configs.js",
+    "watch:test:configs": "npm run test:configs -- -w",
+
+    "test:all": "npm-run-all --parallel test test:configs",
+    "watch:test:all": "npm-run-all --parallel watch:test watch:test:configs",
+
+    "test:specific:config": "ava tests/specific-config.js",
+    "watch:test:specific:config": "npm run test:specific:config -- -w",
+
     "release": "npm run build && with-package git commit -am pkg.version && with-package git tag pkg.version && git push && npm publish && git push --tags",
     "release:beta": "npm run release && npm run tag:beta",
     "tag:beta": "with-package npm dist-tag add pkg.name@pkg.version beta"
@@ -41,7 +45,7 @@
   },
   "devDependencies": {
     "autoprefixer": "6.3.3",
-    "ava": "0.12.0",
+    "ava": "0.13.0",
     "babel-cli": "6.5.1",
     "babel-core": "6.5.2",
     "babel-preset-es2015": "6.5.0",
@@ -88,5 +92,19 @@
       "commit-msg": "validate-commit-msg",
       "pre-commit": "npm run validate -s"
     }
+  },
+  "ava": {
+    "verbose": true,
+    "files": [
+      "src/**/*.test.js"
+    ],
+    "source": [
+      "./src/**/*.js",
+      "./tests/passing-configs/*.js"
+    ],
+    "require": [
+      "./other/setup-ava-env.js"
+    ],
+    "babel": "inherit"
   }
 }


### PR DESCRIPTION
I refactored the test scripts to use the watch flag introducted in ava 0.13. This speeds up reload quite a bit. 
I also extracted common ava cli flags into the ava package.json config entry. 
Finally I documented the available testing commands in CONTRIBUTING.md.