### PR TITLE
feat(cache): Add cache validator

### DIFF
--- a/src/utils/friendly-type-of/index.js
+++ b/src/utils/friendly-type-of/index.js
@@ -1,0 +1,18 @@
+import {find} from 'lodash'
+export {friendlyTypeOf}
+const typesAndInstances = [
+  {instance: Date, type: 'date'},
+  {instance: RegExp, type: 'regex'},
+  {instance: Boolean, type: 'boolean'},
+  {instance: Number, type: 'number'},
+  {instance: Array, type: 'array'},
+]
+
+function friendlyTypeOf(value) {
+  if (value === null) {
+    return 'null'
+  }
+  const {type} = find(typesAndInstances, ({instance}) => value instanceof instance) || {}
+  return type || typeof value
+}
+

--- a/src/utils/friendly-type-of/index.test.js
+++ b/src/utils/friendly-type-of/index.test.js
@@ -1,0 +1,21 @@
+import test from 'ava'
+import {friendlyTypeOf} from './index'
+
+const tests = [
+  {type: 'array', val: []},
+  {type: 'null', val: null},
+  {type: 'boolean', val: true},
+  {type: 'boolean', val: false},
+  {type: 'object', val: {}},
+  {type: 'date', val: new Date()},
+  {type: 'number', val: 3},
+  {type: 'undefined', val: undefined},
+  {type: 'regex', val: /wookie/},
+]
+
+tests.forEach(({type, val}) => {
+  test(`${type}: ${val}`, t => {
+    t.same(friendlyTypeOf(val), type)
+  })
+})
+

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,1 @@
+export * from './friendly-type-of'

--- a/src/validators/cache/index.js
+++ b/src/validators/cache/index.js
@@ -1,6 +1,14 @@
-import {noop} from 'lodash'
+import {friendlyTypeOf} from '../../utils'
+
 export default {
   key: 'cache',
-  validate: noop,
+  validate: validateCache,
+}
+
+function validateCache(value) {
+  const type = friendlyTypeOf(value)
+  if (type !== 'boolean' && type !== 'object') {
+    return `Unexpected type ${type}. Must be a boolean or an object`
+  }
 }
 

--- a/src/validators/cache/index.test.js
+++ b/src/validators/cache/index.test.js
@@ -1,0 +1,22 @@
+import test from 'ava'
+import cacheValidator from './index'
+import {friendlyTypeOf} from '../../utils'
+const {validate} = cacheValidator
+
+const validValues = [true, false, {}]
+const invalidValues = [3, [], null, 'hi', /octocat/]
+
+validValues.forEach(val => {
+  test(`${typeof val}: ${val}`, t => t.true(validate(val) === undefined))
+})
+
+invalidValues.forEach(val => {
+  const type = friendlyTypeOf(val)
+  test(`${type}: ${val}`, t => {
+    t.same(
+      validate(val),
+      `Unexpected type ${type}. Must be a boolean or an object`
+    )
+  })
+})
+


### PR DESCRIPTION
This one should have two reviewers I think. I've added a `utils` directory for utility functions to use throughout the codebase. The first of these is `friendly-type-of` which gives us more helpful output than `typeof []` or `typeof new RegExp()` :-)